### PR TITLE
Allow signature form helper to pass options

### DIFF
--- a/lib/john_hancock/rails/form_builder.rb
+++ b/lib/john_hancock/rails/form_builder.rb
@@ -3,17 +3,18 @@ module JohnHancock
     module FormBuilder
       include ActionView::Helpers::TagHelper
 
-      def signature_canvas
-        content_tag(:canvas, nil, id: 'JohnHancock-canvas')
+      def signature_canvas(options = {})
+        options.merge!(id: 'JohnHancock-canvas')
+        content_tag(:canvas, nil, options)
       end
 
       def hidden_signature_field(attribute)
         hidden_field(attribute.to_sym, id: 'JohnHancock-hidden')
       end
 
-      def signature_field(attribute)
+      def signature_field(attribute, options = {})
         tags = []
-        tags << signature_canvas
+        tags << signature_canvas(options)
         tags << hidden_signature_field(attribute)
         tags.join(' ').html_safe
       end


### PR DESCRIPTION
This update allows the canvas element to be styled. This is useful when using css libraries like tailwind or bootstrap.

ex:

```
<%= f.signature_field :signature, class: "w-full rounded-md bg-slate-50 border-solid border-gray-300" %>
```